### PR TITLE
Turn off ControlLoop in Disconnect

### DIFF
--- a/ugv_sdk/src/mobile_base.cpp
+++ b/ugv_sdk/src/mobile_base.cpp
@@ -35,6 +35,7 @@ void MobileBase::Connect(std::string dev_name, int32_t baud_rate) {
 }
 
 void MobileBase::Disconnect() {
+  keep_running_ = false;
   if (can_connected_) can_if_->StopService();
   if (serial_connected_ && serial_if_->IsOpened()) {
     serial_if_->StopService();


### PR DESCRIPTION
I'm confused why only `keep_running_` is set to false in `Terminate()` and not also `Disconnect()`, as I do not want to `std::terminate()`! Thus, only Disconnect()-ing and destructing results in a segfault in `SendRobotCmd()`
