### PR TITLE
Fix position of catkin_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,12 @@ if(CATKIN_DEVEL_PREFIX)
     message(STATUS "Build package with catkin")
     set(BUILD_WITHOUT_ROS OFF)
     find_package(catkin REQUIRED)
+    catkin_package(
+        LIBRARIES ${PROJECT_NAME}
+        INCLUDE_DIRS include 
+        # CATKIN_DEPENDS async_port
+        # DEPENDS system_lib
+    )
 else()
     message(STATUS "Build package with cmake")
     set(BUILD_WITHOUT_ROS ON)    
@@ -186,13 +192,6 @@ if(BUILD_WITHOUT_ROS) # BUILD_WITHOUT_ROS
     include(CPack)
 
 else() # BUILD_WITHOUT_ROS
-
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include 
-        # CATKIN_DEPENDS async_port
-        # DEPENDS system_lib
-    )
 
     ## Add catkin install targets
     install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
According to http://wiki.ros.org/catkin/CMakeLists.txt#Example, should be located before add_library/add_executable.