### PR TITLE
stop io ctx on destruct

### DIFF
--- a/include/ugv_sdk/utilities/protocol_detector.hpp
+++ b/include/ugv_sdk/utilities/protocol_detector.hpp
@@ -18,6 +18,8 @@
 namespace westonrobot {
 class ProtocolDectctor {
  public:
+  ~ProtocolDectctor();
+
   bool Connect(std::string can_name);
 
   ProtocolVersion DetectProtocolVersion(uint32_t timeout_sec);

--- a/src/utilities/protocol_detector.cpp
+++ b/src/utilities/protocol_detector.cpp
@@ -11,6 +11,11 @@
 #include "utilities/stopwatch.hpp"
 
 namespace westonrobot {
+
+ProtocolDectctor::~ProtocolDectctor() {
+  can_->StopService();
+}
+
 bool ProtocolDectctor::Connect(std::string can_name) {
   can_ = std::make_shared<AsyncCAN>(can_name);
   can_->SetReceiveCallback(


### PR DESCRIPTION
This fix prevents invalid reference to `AsyncCAN::io_context_`.
`ProtocolDectctor::io_thread_` does not joined when `ProtocolDectctor` is destroyed, so that thread continues to access to `this` (which is pointer to destroyed `ProtocolDectctor`).
This is very fatal to program execution.

I think `StopService` must be called in the `AsyncCAN::~AsyncCAN()` according to RAII pattern but since I do not have an knowledge of the codes that use this class, I implemented it here.

Also, there is a typo `ProtocolDectctor` -> `ProtocolDetector`.