### PR TITLE
protocol_v2: fixed steering angle feedback calculation

### DIFF
--- a/src/protocol_v2/agilex_msg_parser_v2.c
+++ b/src/protocol_v2/agilex_msg_parser_v2.c
@@ -91,7 +91,7 @@ bool DecodeCanFrameV2(const struct can_frame *rx_frame, AgxMessage *msg) {
       msg->body.motion_state_msg.steering_angle =
           (int16_t)((uint16_t)(frame->steering_angle.low_byte) |
                     (uint16_t)(frame->steering_angle.high_byte) << 8) /
-          100.0;
+          1000.0;
       break;
     }
     case CAN_MSG_LIGHT_STATE_ID: {


### PR DESCRIPTION
* The angle calculation should be using 1000 instead of 100 for all robots except the Ranger series.
* A fix to the Ranger series will be provided separately