### PR TITLE
Negative motor currents are not correctly converted, overflow to 65535

### DIFF
--- a/src/protocol_v1/agilex_msg_parser_v1.c
+++ b/src/protocol_v1/agilex_msg_parser_v1.c
@@ -78,9 +78,8 @@ bool DecodeCanFrameV1(const struct can_frame *rx_frame, AgxMessage *msg) {
       msg->type = AgxMsgActuatorStateV1;
       msg->body.v1_actuator_state_msg.motor_id =
           rx_frame->can_id - CAN_MSG_ACTUATOR1_STATE_ID;
-      msg->body.v1_actuator_state_msg.current =
-          ((((uint16_t)rx_frame->data[0]) << 8) | (uint16_t)rx_frame->data[1]) /
-          10.0f;
+      msg->body.v1_actuator_state_msg.current = (int16_t)((
+          ((uint16_t)rx_frame->data[0]) << 8) | (uint16_t)rx_frame->data[1]) * 0.1;
       msg->body.v1_actuator_state_msg.rpm = (int16_t)((
           (((uint16_t)rx_frame->data[2]) << 8) | (uint16_t)rx_frame->data[3]));
       msg->body.v1_actuator_state_msg.driver_temp = rx_frame->data[4];

--- a/src/protocol_v2/agilex_msg_parser_v2.c
+++ b/src/protocol_v2/agilex_msg_parser_v2.c
@@ -158,9 +158,8 @@ bool DecodeCanFrameV2(const struct can_frame *rx_frame, AgxMessage *msg) {
           (int16_t)((uint16_t)(frame->rpm.low_byte) |
                     (uint16_t)(frame->rpm.high_byte) << 8);
       msg->body.actuator_hs_state_msg.current =
-          ((uint16_t)(frame->current.low_byte) |
-           (uint16_t)(frame->current.high_byte) << 8) *
-          0.1;
+          (int16_t)((uint16_t)(frame->current.low_byte) |
+                    (uint16_t)(frame->current.high_byte) << 8) * 0.1;
       msg->body.actuator_hs_state_msg.pulse_count =
           (int32_t)((uint32_t)(frame->pulse_count.lsb) |
                     (uint32_t)(frame->pulse_count.low_byte) << 8 |


### PR DESCRIPTION
A cast from uint to int in the parsing of motor currents is missing, this causes an overflow in case of negative currents.